### PR TITLE
Fix processor artifact example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Generic Enums requires Java 1.8 or later.
                 <annotationProcessorPaths>
                     <path>
                         <groupId>io.github.cmoine</groupId>
-                        <artifactId>generic-enums-annotations</artifactId>
+                        <artifactId>generic-enums-processor</artifactId>
                         <version>${generic.enums.version}</version>
                     </path>
                 </annotationProcessorPaths>


### PR DESCRIPTION
Fixed example maven configuration. Annotation plugin should reference processor artifact not annotation artifact.